### PR TITLE
Update nle version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN git clone https://github.com/werner-duvaud/muzero-general /muzero && cd /muz
 RUN patch -d /muzero muzero.patch
 
 RUN git clone https://github.com/facebookresearch/nle.git /nle --recursive \
- && cd /nle && git checkout v0.7.3 \
+ && cd /nle && git checkout v0.9.0 \
  && sed '/#define NLE_ALLOW_SEEDING 1/i#define NLE_ALLOW_SEEDING 1' /nle/include/nleobs.h -i \
  && sed '/self\.env\.set_initial_seeds = f/d' /nle/nle/env/tasks.py -i \
  && sed '/self\.env\.set_current_seeds = f/d' /nle/nle/env/tasks.py -i \


### PR DESCRIPTION
The 0.7.3 version of nle causes problems when building the autoascend docker image. Updating the version to the latest 0.9.0 allows the build to complete without error. 

The following is the error message when building with 0.7.3:

```
 => ERROR [10/16] RUN cd /nle && python setup.py install                                                                                               8.2s
------                                                                                                                                                      
 > [10/16] RUN cd /nle && python setup.py install:                                                                                                          
#14 0.510 Building wheel nle-0.7.3+da62293                                                                                                                  
#14 0.510 running install                                                                                                                                   
#14 0.671 running bdist_egg                                                                                                                                 
#14 0.672 running egg_info                                                                                                                                  
#14 0.672 creating nle.egg-info
#14 0.672 writing nle.egg-info/PKG-INFO
#14 0.672 writing dependency_links to nle.egg-info/dependency_links.txt
#14 0.672 writing entry points to nle.egg-info/entry_points.txt
#14 0.673 writing requirements to nle.egg-info/requires.txt
#14 0.673 writing top-level names to nle.egg-info/top_level.txt
#14 0.673 writing manifest file 'nle.egg-info/SOURCES.txt'
#14 0.688 package init file 'nle/tests/__init__.py' not found (or not a regular file)
#14 0.689 reading manifest file 'nle.egg-info/SOURCES.txt'
#14 0.689 reading manifest template 'MANIFEST.in'
#14 0.710 warning: no previously-included files matching '*' found under directory 'build'
#14 0.711 warning: no previously-included files found matching 'nle/dashboard'
#14 0.711 warning: no previously-included files found matching 'nle/scripts/nh-clean-install.sh'
#14 0.712 warning: no previously-included files found matching 'nle/scripts/run-clang-format.py'
#14 0.712 adding license file 'LICENSE'
#14 0.712 warning: no previously-included files found matching 'nle/scripts/line-changed.sh'
#14 0.720 writing manifest file 'nle.egg-info/SOURCES.txt'
#14 0.720 installing library code to build/bdist.linux-x86_64/egg
#14 0.720 running install_lib
#14 0.720 running build_py
#14 0.721 creating build
#14 0.721 creating build/lib.linux-x86_64-3.8
#14 0.721 creating build/lib.linux-x86_64-3.8/nle
#14 0.721 copying nle/__init__.py -> build/lib.linux-x86_64-3.8/nle
#14 0.721 copying nle/version.py -> build/lib.linux-x86_64-3.8/nle
#14 0.721 creating build/lib.linux-x86_64-3.8/nle/env
#14 0.721 copying nle/env/tasks.py -> build/lib.linux-x86_64-3.8/nle/env
#14 0.722 copying nle/env/base.py -> build/lib.linux-x86_64-3.8/nle/env
#14 0.722 copying nle/env/__init__.py -> build/lib.linux-x86_64-3.8/nle/env
#14 0.722 creating build/lib.linux-x86_64-3.8/nle/nethack
#14 0.722 copying nle/nethack/nethack.py -> build/lib.linux-x86_64-3.8/nle/nethack
#14 0.723 copying nle/nethack/__init__.py -> build/lib.linux-x86_64-3.8/nle/nethack
#14 0.723 copying nle/nethack/actions.py -> build/lib.linux-x86_64-3.8/nle/nethack
#14 0.723 creating build/lib.linux-x86_64-3.8/nle/agent
#14 0.723 copying nle/agent/agent.py -> build/lib.linux-x86_64-3.8/nle/agent
#14 0.724 copying nle/agent/__init__.py -> build/lib.linux-x86_64-3.8/nle/agent
#14 0.724 copying nle/agent/vtrace.py -> build/lib.linux-x86_64-3.8/nle/agent
#14 0.724 creating build/lib.linux-x86_64-3.8/nle/scripts
#14 0.724 copying nle/scripts/check_nethack_speed.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.724 copying nle/scripts/collect_env.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/plot.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/play.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/read_heaplog.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/ttyplay2.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/ttyplay.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/__init__.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/test_raw_nethack.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.725 copying nle/scripts/read_tty.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.726 copying nle/scripts/ttyrec.py -> build/lib.linux-x86_64-3.8/nle/scripts
#14 0.726 creating build/lib.linux-x86_64-3.8/nle/tests
#14 0.726 copying nle/tests/test_envs.py -> build/lib.linux-x86_64-3.8/nle/tests
#14 0.726 copying nle/tests/test_nethack.py -> build/lib.linux-x86_64-3.8/nle/tests
#14 0.726 copying nle/tests/test_profile.py -> build/lib.linux-x86_64-3.8/nle/tests
#14 0.727 running build_ext
#14 0.787 -- The C compiler identification is GNU 9.4.0
#14 0.835 -- The CXX compiler identification is GNU 9.4.0
#14 0.842 -- Detecting C compiler ABI info
#14 0.895 -- Detecting C compiler ABI info - done
#14 0.902 -- Check for working C compiler: /usr/bin/cc - skipped
#14 0.902 -- Detecting C compile features
#14 0.902 -- Detecting C compile features - done
#14 0.905 -- Detecting CXX compiler ABI info
#14 0.966 -- Detecting CXX compiler ABI info - done
#14 0.974 -- Check for working CXX compiler: /usr/bin/c++ - skipped
#14 0.974 -- Detecting CXX compile features
#14 0.974 -- Detecting CXX compile features - done
#14 0.975 Release build.
#14 0.975 Seeding enabled.
#14 0.975 -- Building nle backend version: 0.7.3
#14 0.975 -- HACKDIR set to: /nle/build/lib.linux-x86_64-3.8/nle/nethackdir
#14 0.981 -- The ASM compiler identification is GNU
#14 0.983 -- Found assembler: /usr/bin/cc
#14 0.994 -- pybind11 v2.6.2 
#14 1.013 -- Found PythonInterp: /opt/conda/bin/python (found version "3.8.10") 
#14 1.037 -- Found PythonLibs: /opt/conda/lib
#14 1.038 -- Performing Test HAS_FLTO
#14 1.127 -- Performing Test HAS_FLTO - Success
#14 1.129 -- Configuring done
#14 1.151 -- Generating done
#14 1.157 -- Build files have been written to: /nle/build/temp.linux-x86_64-3.8
#14 1.196 [1/179] Building ASM object third_party/deboost.context/CMakeFiles/fcontext.dir/asm/ontop_x86_64_sysv_elf_gas.S.o
#14 1.197 [2/179] Building ASM object third_party/deboost.context/CMakeFiles/fcontext.dir/asm/jump_x86_64_sysv_elf_gas.S.o
#14 1.197 [3/179] Building ASM object third_party/deboost.context/CMakeFiles/fcontext.dir/asm/make_x86_64_sysv_elf_gas.S.o
#14 1.243 [4/179] Building C object util/CMakeFiles/dlb.dir/panic.c.o
#14 1.247 [5/179] Building C object util/CMakeFiles/dlb.dir/__/src/alloc.c.o
#14 1.254 [6/179] Building C object CMakeFiles/nethackdl.dir/sys/unix/nledl.c.o
#14 1.254 [7/179] Building C object third_party/deboost.context/CMakeFiles/fcontext.dir/source/stack.c.o
#14 1.274 [8/179] Linking C static library libnethackdl.a
#14 1.275 [9/179] Linking C static library third_party/deboost.context/libfcontext.a
#14 1.284 [10/179] Building C object util/CMakeFiles/makedefs.dir/__/src/objects.c.o
#14 1.287 [11/179] Building C object util/CMakeFiles/recover.dir/recover.c.o
#14 1.291 [12/179] Building C object util/CMakeFiles/makedefs.dir/__/src/monst.c.o
#14 1.310 [13/179] Linking C executable util/recover
#14 1.330 [14/179] Building C object util/CMakeFiles/dlb.dir/__/src/dlb.c.o
#14 1.335 [15/179] Building C object util/CMakeFiles/dlb.dir/dlb_main.c.o
#14 1.358 [16/179] Linking C executable util/dlb
#14 1.616 [17/179] Building C object util/CMakeFiles/makedefs.dir/makedefs.c.o
#14 1.616 /nle/util/makedefs.c: In function ‘do_date’:
#14 1.616 /nle/util/makedefs.c:1246:58: warning: ‘%s’ directive writing up to 59 bytes into a region of size between 32 and 221 [-Wformat-overflow=]
#14 1.616  1246 |     Sprintf(outbuf, "%s NetHack%s Version %s%s - last %s %s.", PORT_ID,
#14 1.616       |                                                          ^~
#14 1.616 In file included from /usr/include/stdio.h:867,
#14 1.616                  from /nle/include/global.h:9,
#14 1.616                  from /nle/include/config.h:594,
#14 1.616                  from /nle/util/makedefs.c:11:
#14 1.616 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 37 and 285 bytes into a destination of size 256
#14 1.616    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 1.616       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 1.616    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 1.616       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 1.639 [18/179] Linking C executable util/makedefs
#14 1.649 [19/179] Generating ../include/onames.h
#14 1.649 [20/179] Generating ../include/date.h
#14 1.650 [21/179] Generating ../include/pm.h
#14 1.672 [22/179] Generating lev_scanner.c
#14 1.681 [23/179] Generating dgn_scanner.c
#14 1.727 [24/179] Generating dgn_parser.c, dgn_comp.h
#14 1.747 [25/179] Building C object CMakeFiles/_pynethack.dir/src/decl.c.o
#14 1.771 [26/179] Building C object CMakeFiles/_pynethack.dir/src/objects.c.o
#14 1.779 [27/179] Building C object CMakeFiles/_pynethack.dir/src/monst.c.o
#14 1.789 [28/179] Building C object util/CMakeFiles/dgn_comp.dir/__/src/alloc.c.o
#14 1.799 [29/179] Building C object util/CMakeFiles/dgn_comp.dir/panic.c.o
#14 1.822 [30/179] Building C object util/CMakeFiles/dgn_comp.dir/dgn_main.c.o
#14 1.854 [31/179] Building C object CMakeFiles/_pynethack.dir/src/drawing.c.o
#14 2.008 [32/179] Building C object util/CMakeFiles/dgn_comp.dir/dgn_parser.c.o
#14 2.024 [33/179] Generating lev_parser.c, lev_comp.h
#14 2.098 [34/179] Building C object util/CMakeFiles/lev_comp.dir/panic.c.o
#14 2.107 [35/179] Building C object util/CMakeFiles/lev_comp.dir/__/src/alloc.c.o
#14 2.123 [36/179] Building C object util/CMakeFiles/dgn_comp.dir/dgn_scanner.c.o
#14 2.125 [37/179] Building C object util/CMakeFiles/lev_comp.dir/__/src/decl.c.o
#14 2.149 [38/179] Building C object util/CMakeFiles/lev_comp.dir/__/src/objects.c.o
#14 2.152 [39/179] Linking C executable util/dgn_comp
#14 2.162 [40/179] Building C object util/CMakeFiles/lev_comp.dir/__/src/monst.c.o
#14 2.176 [41/179] Building CXX object CMakeFiles/rlmain.dir/sys/unix/rlmain.cc.o
#14 2.176 /nle/sys/unix/rlmain.cc: In function ‘void play(nle_ctx_t*, nle_obs*)’:
#14 2.176 /nle/sys/unix/rlmain.cc:49:13: warning: ignoring return value of ‘ssize_t read(int, void*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
#14 2.176    49 |         read(STDIN_FILENO, &obs->action, 1);
#14 2.176       |         ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 2.250 [42/179] Linking CXX executable rlmain
#14 2.257 [43/179] Building C object util/CMakeFiles/lev_comp.dir/__/src/drawing.c.o
#14 2.407 [44/179] Building C object util/CMakeFiles/lev_comp.dir/lev_main.c.o
#14 2.537 [45/179] Building C object util/CMakeFiles/lev_comp.dir/lev_parser.c.o
#14 2.766 [46/179] Building C object util/CMakeFiles/lev_comp.dir/lev_scanner.c.o
#14 2.794 [47/179] Linking C executable util/lev_comp
#14 2.807 [48/179] Generating options
#14 2.807 [49/179] Generating oracles
#14 2.808 [50/179] Generating bogusmon, epitaph, engrave
#14 2.809 [51/179] Generating rumors
#14 2.809 [52/179] Generating data
#14 2.810 [53/179] Generating quest.dat
#14 2.810 [54/179] Generating perm, record, logfile, xlogfile
#14 2.818 [55/179] Generating dungeon, dungeon.pdf
#14 2.983 [56/179] Generating Arc-fila.lev, Arc-filb.lev, Arc-goal.lev, Arc-loca.lev, Arc-strt.lev, Bar-fila.lev, Bar-filb.lev, Bar-goal.lev, Bar-loca.lev, Bar-strt.lev, Cav-fila.lev, Cav-filb.lev, Cav-goal.lev, Cav-loca.lev, Cav-strt.lev, Hea-fila.lev, Hea-filb.lev, Hea-goal.lev, Hea-loca.lev, Hea-strt.lev, Kni-fila.lev, Kni-filb.lev, Kni-goal.lev, Kni-loca.lev, Kni-strt.lev, Mon-fila.lev, Mon-filb.lev, Mon-goal.lev, Mon-loca.lev, Mon-strt.lev, Pri-fila.lev, Pri-filb.lev, Pri-goal.lev, Pri-loca.lev, Pri-strt.lev, Ran-fila.lev, Ran-filb.lev, Ran-goal.lev, Ran-loca.lev, Ran-strt.lev, Rog-fila.lev, Rog-filb.lev, Rog-goal.lev, Rog-loca.lev, Rog-strt.lev, Sam-fila.lev, Sam-filb.lev, Sam-goal.lev, Sam-loca.lev, Sam-strt.lev, Tou-fila.lev, Tou-filb.lev, Tou-goal.lev, Tou-loca.lev, Tou-strt.lev, Val-fila.lev, Val-filb.lev, Val-goal.lev, Val-loca.lev, Val-strt.lev, Wiz-fila.lev, Wiz-filb.lev, Wiz-goal.lev, Wiz-loca.lev, Wiz-strt.lev, air.lev, asmodeus.lev, astral.lev, baalz.lev, bigrm-1.lev, bigrm-10.lev, bigrm-2.lev, bigrm-3.lev, bigrm-4.lev, bigrm-5.lev, bigrm-6.lev, bigrm-7.lev, bigrm-8.lev, bigrm-9.lev, castle.lev, earth.lev, fakewiz1.lev, fakewiz2.lev, fire.lev, juiblex.lev, knox.lev, medusa-1.lev, medusa-2.lev, medusa-3.lev, medusa-4.lev, minefill.lev, minend-1.lev, minend-2.lev, minend-3.lev, minetn-1.lev, minetn-2.lev, minetn-3.lev, minetn-4.lev, minetn-5.lev, minetn-6.lev, minetn-7.lev, oracle.lev, orcus.lev, sanctum.lev, soko1-1.lev, soko1-2.lev, soko2-1.lev, soko2-2.lev, soko3-1.lev, soko3-2.lev, soko4-1.lev, soko4-2.lev, tower1.lev, tower2.lev, tower3.lev, valley.lev, water.lev, wizard1.lev, wizard2.lev, wizard3.lev
#14 2.997 [57/179] Generating nhdat
#14 3.139 [58/179] Building C object CMakeFiles/nethack.dir/src/decl.c.o
#14 3.148 [59/179] Building C object CMakeFiles/nethack.dir/src/alloc.c.o
#14 3.300 [60/179] Building C object CMakeFiles/nethack.dir/src/bones.c.o
#14 3.387 [61/179] Building C object CMakeFiles/nethack.dir/src/allmain.c.o
#14 3.483 [62/179] Building C object CMakeFiles/nethack.dir/src/dlb.c.o
#14 3.569 [63/179] Building C object CMakeFiles/nethack.dir/src/ball.c.o
#14 3.572 [64/179] Building C object CMakeFiles/nethack.dir/src/attrib.c.o
#14 3.731 [65/179] Building C object CMakeFiles/nethack.dir/src/dbridge.c.o
#14 4.045 [66/179] Building C object CMakeFiles/nethack.dir/src/artifact.c.o
#14 4.107 [67/179] Building C object CMakeFiles/nethack.dir/src/dig.c.o
#14 4.337 [68/179] Building C object CMakeFiles/nethack.dir/src/detect.c.o
#14 4.339 [69/179] Building C object CMakeFiles/nethack.dir/src/dog.c.o
#14 4.393 [70/179] Building C object CMakeFiles/nethack.dir/src/do.c.o
#14 4.497 [71/179] Building C object CMakeFiles/nethack.dir/src/dogmove.c.o
#14 4.505 [72/179] Building C object CMakeFiles/nethack.dir/src/drawing.c.o
#14 4.571 [73/179] Building C object CMakeFiles/nethack.dir/src/botl.c.o
#14 4.571 /nle/src/botl.c: In function ‘status_hilite_linestr_gather_conditions’:
#14 4.571 /nle/src/botl.c:2793:45: warning: ‘%s’ directive writing up to 255 bytes into a region of size 246 [-Wformat-overflow=]
#14 4.571  2378 |         return buf;
#14 4.571       |                ~~~                           
#14 4.571 ......
#14 4.571  2793 |                 Sprintf(condbuf, "condition/%s/%s",
#14 4.571       |                                             ^~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 12 and 522 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c: In function ‘status_hilite2str’:
#14 4.571 /nle/src/botl.c:2895:24: warning: ‘/’ directive writing 1 byte into a region of size between 0 and 255 [-Wformat-overflow=]
#14 4.571  2895 |     Sprintf(buf, "%s/%s/%s", initblstats[hl->fld].fldname, behavebuf, clrbuf);
#14 4.571       |                        ^
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output 3 or more bytes (assuming 513) into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c: In function ‘do_statusline2’:
#14 4.571 /nle/src/botl.c:224:37: warning: ‘%s’ directive writing up to 127 bytes into a region of size between 0 and 254 [-Wformat-overflow=]
#14 4.571   224 |             Sprintf(newbot2, "%s %s %s %s %s", hlth, cond, dloc, expr, tmmv);
#14 4.571       |                                     ^~                     ~~~~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 5 and 640 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c:222:37: warning: ‘%s’ directive writing up to 127 bytes into a region of size between 0 and 254 [-Wformat-overflow=]
#14 4.571   222 |             Sprintf(newbot2, "%s %s %s %s %s", dloc, hlth, cond, expr, tmmv);
#14 4.571       |                                     ^~                     ~~~~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 5 and 640 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c:220:37: warning: ‘%s’ directive writing up to 127 bytes into a region of size between 0 and 254 [-Wformat-overflow=]
#14 4.571   220 |             Sprintf(newbot2, "%s %s %s %s %s", dloc, hlth, expr, cond, tmmv);
#14 4.571       |                                     ^~                     ~~~~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 5 and 640 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c:214:33: warning: ‘%s’ directive writing up to 127 bytes into a region of size between 0 and 254 [-Wformat-overflow=]
#14 4.571   214 |         Sprintf(newbot2, "%s %s %s %s %s", dloc, hlth, expr, tmmv, cond);
#14 4.571       |                                 ^~                     ~~~~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 5 and 640 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c: In function ‘status_hilite_menu_add’:
#14 4.571 /nle/src/botl.c:3385:38: warning: ‘ or ’ directive writing 4 bytes into a region of size between 1 and 80 [-Wformat-overflow=]
#14 4.571  3385 |                     Sprintf(obuf, "%s or %s",
#14 4.571       |                                      ^~~~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 5 and 163 bytes into a destination of size 80
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c:3330:58: warning: ‘%s’ directive writing up to 255 bytes into a region of size 226 [-Wformat-overflow=]
#14 4.571  2378 |         return buf;
#14 4.571       |                ~~~                                        
#14 4.571 ......
#14 4.571  3330 |         Sprintf(colorqry, "Choose a color for conditions %s:",
#14 4.571       |                                                          ^~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 32 and 287 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571 /nle/src/botl.c:3332:59: warning: ‘%s’ directive writing up to 255 bytes into a region of size 224 [-Wformat-overflow=]
#14 4.571  2378 |         return buf;
#14 4.571       |                ~~~                                         
#14 4.571 ......
#14 4.571  3332 |         Sprintf(attrqry, "Choose attribute for conditions %s:",
#14 4.571       |                                                           ^~
#14 4.571 In file included from /usr/include/stdio.h:867,
#14 4.571                  from /nle/include/global.h:9,
#14 4.571                  from /nle/include/config.h:594,
#14 4.571                  from /nle/include/hack.h:10,
#14 4.571                  from /nle/src/botl.c:6:
#14 4.571 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 34 and 289 bytes into a destination of size 256
#14 4.571    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.571       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.571    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.571       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.593 [74/179] Building C object CMakeFiles/nethack.dir/src/do_name.c.o
#14 4.593 /nle/src/do_name.c: In function ‘getpos_menu’:
#14 4.593 /nle/src/do_name.c:604:37: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
#14 4.593   604 |             Sprintf(fullbuf, "%s%s%s", firstmatch,
#14 4.593       |                                     ^
#14 4.593 In file included from /usr/include/stdio.h:867,
#14 4.593                  from /nle/include/global.h:9,
#14 4.593                  from /nle/include/config.h:594,
#14 4.593                  from /nle/include/hack.h:10,
#14 4.593                  from /nle/src/do_name.c:6:
#14 4.593 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output 1 or more bytes (assuming 257) into a destination of size 256
#14 4.593    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.593       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.593    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.593       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.593 /nle/src/do_name.c: In function ‘getpos’:
#14 4.593 /nle/src/do_name.c:190:31: warning: ‘%s’ directive writing up to 255 bytes into a region of size 249 [-Wformat-overflow=]
#14 4.593   190 |         Sprintf(sbuf, "Type a %s when you are at the right place.", kbuf);
#14 4.593       |                               ^~                                    ~~~~
#14 4.593 In file included from /usr/include/stdio.h:867,
#14 4.593                  from /nle/include/global.h:9,
#14 4.593                  from /nle/include/config.h:594,
#14 4.593                  from /nle/include/hack.h:10,
#14 4.593                  from /nle/src/do_name.c:6:
#14 4.593 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 41 and 296 bytes into a destination of size 256
#14 4.593    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.593       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.593    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.593       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.593 /nle/src/do_name.c:190:31: warning: ‘%s’ directive writing up to 255 bytes into a region of size 249 [-Wformat-overflow=]
#14 4.593   190 |         Sprintf(sbuf, "Type a %s when you are at the right place.", kbuf);
#14 4.593       |                               ^~                                    ~~~~
#14 4.593 In file included from /usr/include/stdio.h:867,
#14 4.593                  from /nle/include/global.h:9,
#14 4.593                  from /nle/include/config.h:594,
#14 4.593                  from /nle/include/hack.h:10,
#14 4.593                  from /nle/src/do_name.c:6:
#14 4.593 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 41 and 296 bytes into a destination of size 256
#14 4.593    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.593       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.593    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.593       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.705 [75/179] Building C object CMakeFiles/nethack.dir/src/do_wear.c.o
#14 4.705 /nle/src/do_wear.c: In function ‘armor_or_accessory_off’:
#14 4.705 /nle/src/do_wear.c:1463:52: warning: ‘%s’ directive writing up to 127 bytes into a region of size 103 [-Wformat-overflow=]
#14 4.705  1463 |             Sprintf(why, " without taking off your %s first", what);
#14 4.705       |                                                    ^~         ~~~~
#14 4.705 In file included from /usr/include/stdio.h:867,
#14 4.705                  from /nle/include/global.h:9,
#14 4.705                  from /nle/include/config.h:594,
#14 4.705                  from /nle/include/hack.h:10,
#14 4.705                  from /nle/src/do_wear.c:6:
#14 4.705 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 32 and 159 bytes into a destination of size 128
#14 4.705    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 4.705       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.705    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 4.705       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 4.717 [76/179] Building C object CMakeFiles/nethack.dir/src/display.c.o
#14 4.820 [77/179] Building C object CMakeFiles/nethack.dir/src/exper.c.o
#14 4.989 [78/179] Building C object CMakeFiles/nethack.dir/src/extralev.c.o
#14 5.023 [79/179] Building C object CMakeFiles/nethack.dir/src/apply.c.o
#14 5.240 [80/179] Building C object CMakeFiles/nethack.dir/src/fountain.c.o
#14 5.273 [81/179] Building C object CMakeFiles/nethack.dir/src/dokick.c.o
#14 5.386 [82/179] Building C object CMakeFiles/nethack.dir/src/engrave.c.o
#14 5.411 [83/179] Building C object CMakeFiles/nethack.dir/src/end.c.o
#14 5.411 /nle/src/end.c: In function ‘list_vanquished’:
#14 5.411 /nle/src/end.c:1997:39: warning: ‘__builtin___sprintf_chk’ may write a terminating nul past the end of the destination [-Wformat-overflow=]
#14 5.411  1997 |                 Sprintf(buftoo, "%*s%s", pfx, "", buf);
#14 5.411       |                                       ^
#14 5.411 In file included from /usr/include/stdio.h:867,
#14 5.411                  from /nle/include/global.h:9,
#14 5.411                  from /nle/include/config.h:594,
#14 5.411                  from /nle/include/hack.h:10,
#14 5.411                  from /nle/src/end.c:8:
#14 5.411 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 1 and 261 bytes into a destination of size 256
#14 5.411    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.411       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.411    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.411       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.416 [84/179] Building C object CMakeFiles/nethack.dir/src/explode.c.o
#14 5.416 /nle/src/explode.c: In function ‘explode’:
#14 5.416 /nle/src/explode.c:539:67: warning: ‘%s’ directive writing up to 255 bytes into a region of size 236 [-Wformat-overflow=]
#14 5.416   539 |                     Sprintf(killer.name, "caught %sself in %s own %s", uhim(),
#14 5.416       |                                                                   ^~
#14 5.416 In file included from /usr/include/stdio.h:867,
#14 5.416                  from /nle/include/global.h:9,
#14 5.416                  from /nle/include/config.h:594,
#14 5.416                  from /nle/include/hack.h:10,
#14 5.416                  from /nle/src/explode.c:5:
#14 5.416 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output 21 or more bytes (assuming 276) into a destination of size 256
#14 5.416    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.416       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.416    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.416       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.495 [85/179] Building C object CMakeFiles/nethack.dir/src/files.c.o
#14 5.522 [86/179] Building C object CMakeFiles/nethack.dir/src/dothrow.c.o
#14 5.567 [87/179] Building C object CMakeFiles/nethack.dir/src/isaac64.c.o
#14 5.588 [88/179] Building C object CMakeFiles/nethack.dir/src/mail.c.o
#14 5.632 [89/179] Building C object CMakeFiles/nethack.dir/src/light.c.o
#14 5.665 [90/179] Building C object CMakeFiles/nethack.dir/src/dungeon.c.o
#14 5.665 /nle/src/dungeon.c: In function ‘print_mapseen’:
#14 5.665 /nle/src/dungeon.c:2886:33: warning: ‘%s’ directive writing up to 255 bytes into a region of size 249 [-Wformat-overflow=]
#14 5.665  2886 |         Sprintf(outbuf, " (play %s to open or close drawbridge)", tmp);
#14 5.665       |                                 ^~                                ~~~
#14 5.665 In file included from /usr/include/stdio.h:867,
#14 5.665                  from /nle/include/global.h:9,
#14 5.665                  from /nle/include/config.h:594,
#14 5.665                  from /nle/include/hack.h:10,
#14 5.665                  from /nle/src/dungeon.c:6:
#14 5.665 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 37 and 292 bytes into a destination of size 256
#14 5.665    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.665       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.665    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.665       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.665 /nle/src/dungeon.c:3047:35: warning: ‘%s’ directive writing up to 255 bytes into a region of size 240 [-Wformat-overflow=]
#14 5.665  3047 |         Sprintf(buf, "%sThe castle%s.", PREFIX, tunesuffix(mptr, tmpbuf));
#14 5.665       |                                   ^~
#14 5.665 In file included from /usr/include/stdio.h:867,
#14 5.665                  from /nle/include/global.h:9,
#14 5.665                  from /nle/include/config.h:594,
#14 5.665                  from /nle/include/hack.h:10,
#14 5.665                  from /nle/src/dungeon.c:6:
#14 5.665 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 18 and 273 bytes into a destination of size 256
#14 5.665    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.665       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.665    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.665       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.665 /nle/src/dungeon.c:3096:40: warning: ‘%s’ directive writing up to 255 bytes into a region of size 242 [-Wformat-overflow=]
#14 5.665  3096 |                 Sprintf(buf, "%s%syou, %s%c", PREFIX, TAB, tmpbuf,
#14 5.665       |                                        ^~                  ~~~~~~
#14 5.665 In file included from /usr/include/stdio.h:867,
#14 5.665                  from /nle/include/global.h:9,
#14 5.665                  from /nle/include/config.h:594,
#14 5.665                  from /nle/include/hack.h:10,
#14 5.665                  from /nle/src/dungeon.c:6:
#14 5.665 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 16 and 271 bytes into a destination of size 256
#14 5.665    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.665       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.665    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.665       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.679 [91/179] Building C object CMakeFiles/nethack.dir/src/hacklib.c.o
#14 5.679 /nle/src/hacklib.c: In function ‘yyyymmddhhmmss’:
#14 5.679 /nle/src/hacklib.c:1023:28: warning: ‘%02d’ directive writing between 2 and 11 bytes into a region of size between 4 and 11 [-Wformat-overflow=]
#14 5.679  1023 |     Sprintf(datestr, "%04ld%02d%02d%02d%02d%02d", datenum, lt->tm_mon + 1,
#14 5.679       |                            ^~~~
#14 5.679 /nle/src/hacklib.c:1023:22: note: directive argument in the range [-2147483647, 2147483647]
#14 5.679  1023 |     Sprintf(datestr, "%04ld%02d%02d%02d%02d%02d", datenum, lt->tm_mon + 1,
#14 5.679       |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.679 In file included from /usr/include/stdio.h:867,
#14 5.679                  from /nle/include/global.h:9,
#14 5.679                  from /nle/include/config.h:594,
#14 5.679                  from /nle/include/hack.h:10,
#14 5.679                  from /nle/src/hacklib.c:8:
#14 5.679 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 15 and 67 bytes into a destination of size 15
#14 5.679    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.679       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.679    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.679       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.752 [92/179] Building C object CMakeFiles/nethack.dir/src/cmd.c.o
#14 5.753 /nle/src/cmd.c: In function ‘paranoid_query.part.0’:
#14 5.753 /nle/src/cmd.c:6094:30: warning: ‘%s’ directive writing up to 255 bytes into a region of size between 113 and 128 [-Wformat-overflow=]
#14 5.753  6094 |             Sprintf(qbuf, "%s%s %s", promptprefix, pbuf, responsetype);
#14 5.753       |                              ^~                    ~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 10 and 282 bytes into a destination of size 128
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753 /nle/src/cmd.c: In function ‘background_enlightenment.isra.0’:
#14 5.753 /nle/src/cmd.c:1861:28: warning: ‘%s’ directive writing up to 255 bytes into a region of size 253 [-Wformat-overflow=]
#14 5.753  1861 |         Sprintf(buf, "%sin %s%s form", !final ? "currently " : "", tmpbuf,
#14 5.753       |                            ^~                                      ~~~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output 9 or more bytes (assuming 264) into a destination of size 256
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753 /nle/src/cmd.c:1861:28: warning: ‘%s’ directive writing up to 255 bytes into a region of size 243 [-Wformat-overflow=]
#14 5.753  1861 |         Sprintf(buf, "%sin %s%s form", !final ? "currently " : "", tmpbuf,
#14 5.753       |                            ^~                                      ~~~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output 19 or more bytes (assuming 274) into a destination of size 256
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753 /nle/src/cmd.c:1978:33: warning: ‘%s’ directive writing up to 255 bytes into a region of size between 121 and 248 [-Wformat-overflow=]
#14 5.753  1978 |         Sprintf(buf, "in %s, on %s", dgnbuf, tmpbuf);
#14 5.753       |                                 ^~           ~~~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 9 and 391 bytes into a destination of size 256
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753 /nle/src/cmd.c:1957:48: warning: ‘%s’ directive writing up to 255 bytes into a region of size between 223 and 233 [-Wformat-overflow=]
#14 5.753  1957 |         Sprintf(buf, "in the endgame, on the %s%s",
#14 5.753       |                                                ^~
#14 5.753  1958 |                 !strncmp(tmpbuf, "Plane", 5) ? "Elemental " : "", tmpbuf);
#14 5.753       |                                                                   ~~~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 24 and 289 bytes into a destination of size 256
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753 /nle/src/cmd.c: In function ‘extcmd_via_menu’:
#14 5.753 /nle/src/cmd.c:658:44: warning: ‘%s’ directive writing up to 127 bytes into a region of size 110 [-Wformat-overflow=]
#14 5.753   658 |         Sprintf(prompt, "Extended Command: %s", cbuf);
#14 5.753       |                                            ^~   ~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 19 and 146 bytes into a destination of size 128
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753 /nle/src/cmd.c: In function ‘enlightenment’:
#14 5.753 /nle/src/cmd.c:1785:21: warning: ‘ the ’ directive writing 5 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 5.753  1785 |     Sprintf(buf, "%s the %s's attributes:", tmpbuf,
#14 5.753       |                     ^~~~~
#14 5.753 In file included from /usr/include/stdio.h:867,
#14 5.753                  from /nle/include/global.h:9,
#14 5.753                  from /nle/include/config.h:594,
#14 5.753                  from /nle/include/hack.h:10,
#14 5.753                  from /nle/src/cmd.c:6:
#14 5.753 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output 20 or more bytes (assuming 275) into a destination of size 256
#14 5.753    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 5.753       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.753    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 5.753       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 5.778 [93/179] Building C object CMakeFiles/nethack.dir/src/mapglyph.c.o
#14 6.037 [94/179] Building C object CMakeFiles/nethack.dir/src/eat.c.o
#14 6.037 /nle/src/eat.c: In function ‘edibility_prompts’:
#14 6.037 /nle/src/eat.c:2342:25: warning: ‘ like ’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2342 |         Sprintf(buf, "%s like %s could be tainted!  %s", foodsmell, it_or_they,
#14 6.037       |                         ^~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 27 and 536 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2350:25: warning: ‘ like ’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2350 |         Sprintf(buf, "%s like %s could be something very dangerous!  %s",
#14 6.037       |                         ^~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 44 and 553 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2368:25: warning: ‘ like ’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2368 |         Sprintf(buf, "%s like %s might be poisonous!  %s", foodsmell,
#14 6.037       |                         ^~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 29 and 538 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2377:25: warning: ‘ like ’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2377 |         Sprintf(buf, "%s like %s might have been poisoned.  %s", foodsmell,
#14 6.037       |                         ^~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 35 and 544 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2383:25: warning: ‘ unhealthy.  ’ directive writing 13 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2383 |         Sprintf(buf, "%s unhealthy.  %s", foodsmell, eat_it_anyway);
#14 6.037       |                         ^~~~~~~~~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 14 and 396 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2390:25: warning: ‘ rather acidic.  ’ directive writing 17 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2390 |         Sprintf(buf, "%s rather acidic.  %s", foodsmell, eat_it_anyway);
#14 6.037       |                         ^~~~~~~~~~~~~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 18 and 400 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2398:25: warning: ‘ disgusting to you right now...’ directive writing 31 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2398 |         Sprintf(buf, "%s disgusting to you right now.  %s", foodsmell,
#14 6.037       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 32 and 414 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2413:25: warning: ‘ foul and unfamiliar to you...’ directive writing 30 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2413 |         Sprintf(buf, "%s foul and unfamiliar to you.  %s", foodsmell,
#14 6.037       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 31 and 413 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2433:25: warning: ‘ like ’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2433 |         Sprintf(buf, "%s like %s could be tainted!  %s",
#14 6.037       |                         ^~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 27 and 536 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2424:25: warning: ‘ unfamiliar to you.  ’ directive writing 21 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2424 |         Sprintf(buf, "%s unfamiliar to you.  %s", foodsmell, eat_it_anyway);
#14 6.037       |                         ^~~~~~~~~~~~~~~~~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 22 and 404 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037 /nle/src/eat.c:2359:25: warning: ‘ like ’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 6.037  2359 |         Sprintf(buf, "%s like %s could be rotten! %s",  foodsmell, it_or_they,
#14 6.037       |                         ^~~~~~
#14 6.037 In file included from /usr/include/stdio.h:867,
#14 6.037                  from /nle/include/global.h:9,
#14 6.037                  from /nle/include/config.h:594,
#14 6.037                  from /nle/include/hack.h:10,
#14 6.037                  from /nle/src/eat.c:6:
#14 6.037 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 25 and 534 bytes into a destination of size 256
#14 6.037    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 6.037       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.037    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 6.037       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 6.253 [95/179] Building C object CMakeFiles/nethack.dir/src/mkmap.c.o
#14 6.266 [96/179] Building C object CMakeFiles/nethack.dir/src/lock.c.o
#14 6.330 [97/179] Building C object CMakeFiles/nethack.dir/src/minion.c.o
#14 6.376 [98/179] Building C object CMakeFiles/nethack.dir/src/mcastu.c.o
#14 6.550 [99/179] Building C object CMakeFiles/nethack.dir/src/monst.c.o
#14 6.632 [100/179] Building C object CMakeFiles/nethack.dir/src/makemon.c.o
#14 6.658 [101/179] Building C object CMakeFiles/nethack.dir/src/mkroom.c.o
#14 6.877 [102/179] Building C object CMakeFiles/nethack.dir/src/mplayer.c.o
#14 6.884 [103/179] Building C object CMakeFiles/nethack.dir/src/mondata.c.o
#14 6.963 [104/179] Building C object CMakeFiles/nethack.dir/src/nle.c.o
#14 6.964 FAILED: CMakeFiles/nethack.dir/src/nle.c.o 
#14 6.964 /usr/bin/cc -DDEFAULT_WINDOW_SYS=\"rl\" -DDLB -DGCC_WARN -DHACKDIR=\"/nle/build/lib.linux-x86_64-3.8/nle/nethackdir\" -DNLE_ALLOW_SEEDING -DNOCLIPPING -DNOCWD_ASSUMPTIONS -DNOMAIL -DNOTPARMDECL -Dnethack_EXPORTS -I/nle/include -I/nle/build/temp.linux-x86_64-3.8/include -I/nle/third_party/libtmt -I/nle/third_party/deboost.context/include -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/nethack.dir/src/nle.c.o -MF CMakeFiles/nethack.dir/src/nle.c.o.d -o CMakeFiles/nethack.dir/src/nle.c.o -c /nle/src/nle.c
#14 6.964 /nle/src/nle.c:6:10: fatal error: tmt.h: No such file or directory
#14 6.964     6 | #include <tmt.h>
#14 6.964       |          ^~~~~~~
#14 6.964 compilation terminated.
#14 7.060 [105/179] Building C object CMakeFiles/nethack.dir/src/mklev.c.o
#14 7.072 [106/179] Building C object CMakeFiles/nethack.dir/src/hack.c.o
#14 7.077 [107/179] Building C object CMakeFiles/nethack.dir/src/mkmaze.c.o
#14 7.152 [108/179] Building C object CMakeFiles/nethack.dir/src/mkobj.c.o
#14 7.333 [109/179] Building C object CMakeFiles/nethack.dir/src/invent.c.o
#14 7.372 [110/179] Building C object CMakeFiles/nethack.dir/src/mthrowu.c.o
#14 7.388 [111/179] Building C object CMakeFiles/nethack.dir/src/mhitu.c.o
#14 7.449 [112/179] Building C object CMakeFiles/nethack.dir/src/music.c.o
#14 7.647 [113/179] Building C object CMakeFiles/nethack.dir/src/monmove.c.o
#14 7.770 [114/179] Building C object CMakeFiles/nethack.dir/src/mhitm.c.o
#14 7.770 /nle/src/mhitm.c: In function ‘hitmm’:
#14 7.770 /nle/src/mhitm.c:606:37: warning: ‘ squeezes’ directive writing 9 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 7.770   606 |                     Sprintf(buf, "%s squeezes", magr_name);
#14 7.770       |                                     ^~~~~~~~~
#14 7.770 In file included from /usr/include/stdio.h:867,
#14 7.770                  from /nle/include/global.h:9,
#14 7.770                  from /nle/include/config.h:594,
#14 7.770                  from /nle/include/hack.h:10,
#14 7.770                  from /nle/src/mhitm.c:6:
#14 7.770 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 10 and 265 bytes into a destination of size 256
#14 7.770    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 7.770       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 7.770       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770 /nle/src/mhitm.c:593:33: warning: ‘ stings’ directive writing 7 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 7.770   593 |                 Sprintf(buf, "%s stings", magr_name);
#14 7.770       |                                 ^~~~~~~
#14 7.770 In file included from /usr/include/stdio.h:867,
#14 7.770                  from /nle/include/global.h:9,
#14 7.770                  from /nle/include/config.h:594,
#14 7.770                  from /nle/include/hack.h:10,
#14 7.770                  from /nle/src/mhitm.c:6:
#14 7.770 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 8 and 263 bytes into a destination of size 256
#14 7.770    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 7.770       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 7.770       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770 /nle/src/mhitm.c:599:33: warning: ‘ touches’ directive writing 8 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 7.770   599 |                 Sprintf(buf, "%s touches", magr_name);
#14 7.770       |                                 ^~~~~~~~
#14 7.770 In file included from /usr/include/stdio.h:867,
#14 7.770                  from /nle/include/global.h:9,
#14 7.770                  from /nle/include/config.h:594,
#14 7.770                  from /nle/include/hack.h:10,
#14 7.770                  from /nle/src/mhitm.c:6:
#14 7.770 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 9 and 264 bytes into a destination of size 256
#14 7.770    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 7.770       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 7.770       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770 /nle/src/mhitm.c:596:33: warning: ‘ butts’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 7.770   596 |                 Sprintf(buf, "%s butts", magr_name);
#14 7.770       |                                 ^~~~~~
#14 7.770 In file included from /usr/include/stdio.h:867,
#14 7.770                  from /nle/include/global.h:9,
#14 7.770                  from /nle/include/config.h:594,
#14 7.770                  from /nle/include/hack.h:10,
#14 7.770                  from /nle/src/mhitm.c:6:
#14 7.770 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 7 and 262 bytes into a destination of size 256
#14 7.770    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 7.770       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 7.770       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770 /nle/src/mhitm.c:590:33: warning: ‘ bites’ directive writing 6 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 7.770   590 |                 Sprintf(buf, "%s bites", magr_name);
#14 7.770       |                                 ^~~~~~
#14 7.770 In file included from /usr/include/stdio.h:867,
#14 7.770                  from /nle/include/global.h:9,
#14 7.770                  from /nle/include/config.h:594,
#14 7.770                  from /nle/include/hack.h:10,
#14 7.770                  from /nle/src/mhitm.c:6:
#14 7.770 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 7 and 262 bytes into a destination of size 256
#14 7.770    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 7.770       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 7.770       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770 /nle/src/mhitm.c:611:33: warning: ‘ hits’ directive writing 5 bytes into a region of size between 1 and 256 [-Wformat-overflow=]
#14 7.770   611 |                 Sprintf(buf, "%s hits", magr_name);
#14 7.770       |                                 ^~~~~
#14 7.770 In file included from /usr/include/stdio.h:867,
#14 7.770                  from /nle/include/global.h:9,
#14 7.770                  from /nle/include/config.h:594,
#14 7.770                  from /nle/include/hack.h:10,
#14 7.770                  from /nle/src/mhitm.c:6:
#14 7.770 /usr/include/x86_64-linux-gnu/bits/stdio2.h:36:10: note: ‘__builtin___sprintf_chk’ output between 6 and 261 bytes into a destination of size 256
#14 7.770    36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
#14 7.770       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.770    37 |       __bos (__s), __fmt, __va_arg_pack ());
#14 7.770       |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#14 7.806 [115/179] Building C object CMakeFiles/nethack.dir/src/muse.c.o
#14 7.973 [116/179] Building C object CMakeFiles/nethack.dir/src/mon.c.o
#14 8.110 [117/179] Building CXX object CMakeFiles/_pynethack.dir/win/rl/pynethack.cc.o
#14 8.110 ninja: build stopped: subcommand failed.
------
executor failed running [/bin/sh -c cd /nle && python setup.py install]: exit code: 1
```